### PR TITLE
Implement production-ready map experience

### DIFF
--- a/numyp/lib/config/constants.dart
+++ b/numyp/lib/config/constants.dart
@@ -1,9 +1,24 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+
 class AppConstants {
-  /// APIのベースURL。本番環境では--dart-defineで上書きしてください。
-  static const String apiBaseUrl = String.fromEnvironment(
-    'API_BASE_URL',
-    defaultValue: 'http://localhost:8000',
-  );
+  static Map<String, dynamic>? _envConfig;
+
+  /// env.jsonを読み込む
+  static Future<void> loadEnv() async {
+    final String envString = await rootBundle.loadString('env.json');
+    _envConfig = json.decode(envString);
+  }
+
+  /// APIのベースURL
+  static String get apiBaseUrl {
+    return _envConfig?['API_BASE_URL'] ?? 'http://localhost:8000';
+  }
+
+  /// Google Maps API Key
+  static String get gmapApiKey {
+    return _envConfig?['GMAP_API_KEY'] ?? '';
+  }
 
   /// 地図初期位置
   static const double initialLatitude = 35.6377437;

--- a/numyp/lib/config/constants.dart
+++ b/numyp/lib/config/constants.dart
@@ -1,0 +1,15 @@
+class AppConstants {
+  /// APIのベースURL。本番環境では--dart-defineで上書きしてください。
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:8000',
+  );
+
+  /// 地図初期位置
+  static const double initialLatitude = 35.6377437;
+  static const double initialLongitude = 140.2032806;
+  static const double initialZoom = 17.0;
+
+  /// API通信のタイムアウト秒数
+  static const int requestTimeoutSeconds = 20;
+}

--- a/numyp/lib/main.dart
+++ b/numyp/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'config/constants.dart';
 import 'config/theme.dart';
 import 'screens/map/map_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await AppConstants.loadEnv();
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/numyp/lib/models/spot.dart
+++ b/numyp/lib/models/spot.dart
@@ -1,0 +1,134 @@
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class Spot {
+  Spot({
+    required this.id,
+    required this.createdAt,
+    required this.location,
+    required this.content,
+    required this.status,
+    required this.author,
+    required this.skin,
+  });
+
+  final String id;
+  final DateTime createdAt;
+  final LatLng location;
+  final SpotContent content;
+  final SpotStatus status;
+  final AuthorInfo author;
+  final SkinInfo skin;
+
+  factory Spot.fromJson(Map<String, dynamic> json) {
+    return Spot(
+      id: json['id'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      location: LatLng(
+        (json['location']['lat'] as num).toDouble(),
+        (json['location']['lng'] as num).toDouble(),
+      ),
+      content: SpotContent.fromJson(json['content'] as Map<String, dynamic>),
+      status: SpotStatus.fromJson(json['status'] as Map<String, dynamic>),
+      author: AuthorInfo.fromJson(json['author'] as Map<String, dynamic>),
+      skin: SkinInfo.fromJson(json['skin'] as Map<String, dynamic>),
+    );
+  }
+}
+
+class SpotContent {
+  SpotContent({
+    required this.title,
+    this.description,
+    this.imageUrl,
+  });
+
+  final String title;
+  final String? description;
+  final String? imageUrl;
+
+  factory SpotContent.fromJson(Map<String, dynamic> json) {
+    return SpotContent(
+      title: json['title'] as String,
+      description: json['description'] as String?,
+      imageUrl: json['image_url'] as String?,
+    );
+  }
+}
+
+class SpotStatus {
+  SpotStatus({
+    required this.crowdLevel,
+    required this.rating,
+  });
+
+  final CrowdLevel crowdLevel;
+  final int rating;
+
+  factory SpotStatus.fromJson(Map<String, dynamic> json) {
+    return SpotStatus(
+      crowdLevel: CrowdLevelExtension.fromString(json['crowd_level'] as String),
+      rating: (json['rating'] as num).toInt(),
+    );
+  }
+}
+
+enum CrowdLevel { low, medium, high }
+
+extension CrowdLevelExtension on CrowdLevel {
+  String get label => switch (this) {
+        CrowdLevel.low => '空いている',
+        CrowdLevel.medium => '普通',
+        CrowdLevel.high => '混雑',
+      };
+
+  static CrowdLevel fromString(String value) {
+    switch (value.toLowerCase()) {
+      case 'low':
+        return CrowdLevel.low;
+      case 'high':
+        return CrowdLevel.high;
+      default:
+        return CrowdLevel.medium;
+    }
+  }
+}
+
+class AuthorInfo {
+  AuthorInfo({
+    required this.id,
+    required this.username,
+    this.iconUrl,
+  });
+
+  final String id;
+  final String username;
+  final String? iconUrl;
+
+  factory AuthorInfo.fromJson(Map<String, dynamic> json) {
+    return AuthorInfo(
+      id: json['id'] as String,
+      username: json['username'] as String,
+      iconUrl: json['icon_url'] as String?,
+    );
+  }
+}
+
+class SkinInfo {
+  SkinInfo({
+    required this.id,
+    required this.name,
+    this.imageUrl,
+  });
+
+  final String id;
+  final String name;
+  final String? imageUrl;
+
+  factory SkinInfo.fromJson(Map<String, dynamic> json) {
+    return SkinInfo(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      imageUrl: json['image_url'] as String?,
+    );
+  }
+}

--- a/numyp/lib/providers/spot_providers.dart
+++ b/numyp/lib/providers/spot_providers.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+import '../models/spot.dart';
+import '../services/api_client.dart';
+
+final apiClientProvider = Provider<ApiClient>((ref) => ApiClient());
+
+final spotsProvider = FutureProvider<List<Spot>>((ref) async {
+  final client = ref.watch(apiClientProvider);
+  return client.fetchSpots();
+});
+
+final selectedSpotProvider = StateProvider<Spot?>((ref) => null);
+
+final markerProvider = Provider<Set<Marker>>((ref) {
+  final spotsAsync = ref.watch(spotsProvider);
+  return spotsAsync.maybeWhen(
+    data: (spots) {
+      return spots
+          .map(
+            (spot) => Marker(
+              markerId: MarkerId(spot.id),
+              position: spot.location,
+              icon: BitmapDescriptor.defaultMarkerWithHue(
+                BitmapDescriptor.hueYellow,
+              ),
+              onTap: () => ref.read(selectedSpotProvider.notifier).state = spot,
+            ),
+          )
+          .toSet();
+    },
+    orElse: () => <Marker>{},
+  );
+});

--- a/numyp/lib/screens/map/map_screen.dart
+++ b/numyp/lib/screens/map/map_screen.dart
@@ -1,101 +1,183 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+import '../../config/constants.dart';
 import '../../config/theme.dart';
+import '../../models/spot.dart';
+import '../../providers/spot_providers.dart';
 import '../../widgets/glass_card.dart';
+import '../../widgets/spot_detail_card.dart';
+import '../../widgets/spot_preview_card.dart';
 
 /// メイン地図画面
-/// 夜のディズニーリゾートをイメージしたデザイン
-class MapScreen extends StatefulWidget {
+/// APIから取得したスポットを表示し、選択できる
+class MapScreen extends ConsumerStatefulWidget {
   const MapScreen({super.key});
 
   @override
-  State<MapScreen> createState() => _MapScreenState();
+  ConsumerState<MapScreen> createState() => _MapScreenState();
 }
 
-class _MapScreenState extends State<MapScreen> {
+class _MapScreenState extends ConsumerState<MapScreen> {
   final Completer<GoogleMapController> _controller =
       Completer<GoogleMapController>();
 
-  // 初期位置: 千城台駅付近
-  static const CameraPosition _kGooglePlex = CameraPosition(
-    target: LatLng(35.6377437, 140.2032806),
-    zoom: 18.0,
-  );
+  late final CameraPosition _initialCameraPosition;
 
   int _currentIndex = 0;
 
   @override
+  void initState() {
+    super.initState();
+    _initialCameraPosition = const CameraPosition(
+      target: LatLng(AppConstants.initialLatitude, AppConstants.initialLongitude),
+      zoom: AppConstants.initialZoom,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final spotsAsync = ref.watch(spotsProvider);
+    final markers = ref.watch(markerProvider);
+    final selectedSpot = ref.watch(selectedSpotProvider);
+
     return Scaffold(
       body: Stack(
         children: [
-          // 1層目: Google Map
           GoogleMap(
             mapType: MapType.hybrid,
-            initialCameraPosition: _kGooglePlex,
+            initialCameraPosition: _initialCameraPosition,
             onMapCreated: (GoogleMapController controller) {
               _controller.complete(controller);
             },
-            // Google Map ID を適用（カスタムスタイル用）
-            // TODO: 将来的に env.json から読み込む
             cloudMapId: null,
-            // 不要なUIを非表示
             zoomControlsEnabled: false,
             mapToolbarEnabled: false,
             myLocationButtonEnabled: false,
+            markers: markers,
           ),
 
-          // 2層目: 上部のステータスバー（コイン・ユーザー情報）
+          // 上部ステータスバー
           Positioned(
             top: MediaQuery.of(context).padding.top + 16,
             left: 16,
             right: 16,
             child: GlassCard(
-              height: 60,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              height: 64,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  // コイン表示
-                  Row(
-                    children: [
-                      Icon(
-                        Icons.monetization_on,
-                        color: AppColors.magicGold,
-                        size: 28,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        '1,234',
-                        style: TextStyle(
-                          color: AppColors.textPrimary,
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                    ],
+                  _buildCoinSection(),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: const [
+                        Text('numyp',
+                            style: TextStyle(
+                              color: AppColors.textPrimary,
+                              fontWeight: FontWeight.w700,
+                              fontSize: 16,
+                            )),
+                        SizedBox(height: 2),
+                        Text('今日のスポットを探索しよう',
+                            style: TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 12,
+                            )),
+                      ],
+                    ),
                   ),
-                  // ユーザーアイコン
-                  CircleAvatar(
-                    radius: 20,
-                    backgroundColor: AppColors.fantasyPurple,
-                    child: Icon(Icons.person, color: Colors.white, size: 24),
-                  ),
+                  _buildIconBadge(),
                 ],
               ),
             ),
           ),
 
-          // 3層目: 右下の現在地ボタン
+          // ローディングやエラーの表示
           Positioned(
-            bottom: 100,
+            top: MediaQuery.of(context).padding.top + 90,
+            left: 16,
             right: 16,
-            child: FloatingActionButton(
-              heroTag: 'location',
-              onPressed: _goToCurrentLocation,
-              backgroundColor: AppColors.cardSurface.withOpacity(0.8),
-              child: Icon(Icons.my_location, color: AppColors.magicGold),
+            child: spotsAsync.when(
+              data: (_) => const SizedBox.shrink(),
+              loading: () => const _StatusBubble(
+                icon: Icons.cloud_download,
+                text: 'スポットを読み込み中...',
+              ),
+              error: (error, _) => _StatusBubble(
+                icon: Icons.error_outline,
+                text: '取得に失敗しました。リトライ',
+                onTap: () => ref.refresh(spotsProvider),
+              ),
+            ),
+          ),
+
+          // 下部のスポットプレビュー
+          if (spotsAsync.hasValue && spotsAsync.value!.isNotEmpty)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 120,
+              child: SizedBox(
+                height: 200,
+                child: ListView.separated(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder: (context, index) {
+                    final spot = spotsAsync.value![index];
+                    return SpotPreviewCard(
+                      spot: spot,
+                      onTap: () {
+                        _moveCamera(spot.location);
+                        ref.read(selectedSpotProvider.notifier).state = spot;
+                      },
+                    );
+                  },
+                  separatorBuilder: (_, __) => const SizedBox(width: 12),
+                  itemCount: spotsAsync.value!.length,
+                ),
+              ),
+            ),
+
+          // 詳細カード
+          if (selectedSpot != null)
+            Positioned(
+              left: 16,
+              right: 16,
+              bottom: 20,
+              child: SpotDetailCard(
+                spot: selectedSpot,
+                onClose: () =>
+                    ref.read(selectedSpotProvider.notifier).state = null,
+              ),
+            ),
+
+          // 現在地 / リフレッシュボタン
+          Positioned(
+            bottom: 220,
+            right: 16,
+            child: Column(
+              children: [
+                FloatingActionButton(
+                  heroTag: 'refresh',
+                  backgroundColor: AppColors.cardSurface.withOpacity(0.85),
+                  onPressed: () => ref.refresh(spotsProvider),
+                  child: const Icon(Icons.refresh, color: AppColors.magicGold),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton(
+                  heroTag: 'location',
+                  backgroundColor: AppColors.cardSurface.withOpacity(0.85),
+                  onPressed: _goToCurrentLocation,
+                  child: const Icon(Icons.my_location,
+                      color: AppColors.magicGold),
+                ),
+              ],
             ),
           ),
         ],
@@ -126,11 +208,93 @@ class _MapScreenState extends State<MapScreen> {
     );
   }
 
+  Widget _buildCoinSection() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: AppColors.cardSurface.withOpacity(0.5),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: Colors.white12),
+      ),
+      child: Row(
+        children: const [
+          Icon(Icons.monetization_on, color: AppColors.magicGold, size: 22),
+          SizedBox(width: 6),
+          Text(
+            '1,234',
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIconBadge() {
+    return Container(
+      padding: const EdgeInsets.all(6),
+      decoration: BoxDecoration(
+        color: AppColors.fantasyPurple.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white10),
+      ),
+      child: const CircleAvatar(
+        radius: 18,
+        backgroundColor: AppColors.fantasyPurple,
+        child: Icon(Icons.person, color: Colors.white),
+      ),
+    );
+  }
+
   /// 現在地へ移動（仮実装）
   Future<void> _goToCurrentLocation() async {
+    if (!_controller.isCompleted) return;
     final GoogleMapController controller = await _controller.future;
     await controller.animateCamera(
-      CameraUpdate.newCameraPosition(_kGooglePlex),
+      CameraUpdate.newCameraPosition(_initialCameraPosition),
+    );
+  }
+
+  Future<void> _moveCamera(LatLng position) async {
+    if (!_controller.isCompleted) return;
+    final GoogleMapController controller = await _controller.future;
+    await controller.animateCamera(
+      CameraUpdate.newCameraPosition(
+        CameraPosition(target: position, zoom: AppConstants.initialZoom + 1),
+      ),
+    );
+  }
+}
+
+class _StatusBubble extends StatelessWidget {
+  const _StatusBubble({required this.icon, required this.text, this.onTap});
+
+  final IconData icon;
+  final String text;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      child: InkWell(
+        onTap: onTap,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, color: AppColors.magicGold),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                text,
+                style: const TextStyle(color: AppColors.textPrimary),
+              ),
+            )
+          ],
+        ),
+      ),
     );
   }
 }

--- a/numyp/lib/screens/map/map_screen.dart
+++ b/numyp/lib/screens/map/map_screen.dart
@@ -33,9 +33,20 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   void initState() {
     super.initState();
     _initialCameraPosition = const CameraPosition(
-      target: LatLng(AppConstants.initialLatitude, AppConstants.initialLongitude),
+      target: LatLng(
+        AppConstants.initialLatitude,
+        AppConstants.initialLongitude,
+      ),
       zoom: AppConstants.initialZoom,
     );
+  }
+
+  @override
+  void dispose() {
+    if (_controller.isCompleted) {
+      _controller.future.then((controller) => controller.dispose());
+    }
+    super.dispose();
   }
 
   @override
@@ -66,8 +77,7 @@ class _MapScreenState extends ConsumerState<MapScreen> {
             left: 16,
             right: 16,
             child: GlassCard(
-              height: 64,
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
               child: Row(
                 children: [
                   _buildCoinSection(),
@@ -76,19 +86,24 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
                       children: const [
-                        Text('numyp',
-                            style: TextStyle(
-                              color: AppColors.textPrimary,
-                              fontWeight: FontWeight.w700,
-                              fontSize: 16,
-                            )),
+                        Text(
+                          'numyp',
+                          style: TextStyle(
+                            color: AppColors.textPrimary,
+                            fontWeight: FontWeight.w700,
+                            fontSize: 16,
+                          ),
+                        ),
                         SizedBox(height: 2),
-                        Text('今日のスポットを探索しよう',
-                            style: TextStyle(
-                              color: AppColors.textSecondary,
-                              fontSize: 12,
-                            )),
+                        Text(
+                          '今日のスポットを探索しよう',
+                          style: TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 12,
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -174,8 +189,10 @@ class _MapScreenState extends ConsumerState<MapScreen> {
                   heroTag: 'location',
                   backgroundColor: AppColors.cardSurface.withOpacity(0.85),
                   onPressed: _goToCurrentLocation,
-                  child: const Icon(Icons.my_location,
-                      color: AppColors.magicGold),
+                  child: const Icon(
+                    Icons.my_location,
+                    color: AppColors.magicGold,
+                  ),
                 ),
               ],
             ),
@@ -291,7 +308,7 @@ class _StatusBubble extends StatelessWidget {
                 text,
                 style: const TextStyle(color: AppColors.textPrimary),
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/numyp/lib/services/api_client.dart
+++ b/numyp/lib/services/api_client.dart
@@ -5,24 +5,27 @@ import '../models/spot.dart';
 
 class ApiClient {
   ApiClient({Dio? dio})
-      : _dio = dio ??
-            Dio(
-              BaseOptions(
-                baseUrl: AppConstants.apiBaseUrl,
-                connectTimeout: const Duration(
-                  seconds: AppConstants.requestTimeoutSeconds,
-                ),
-                receiveTimeout: const Duration(
-                  seconds: AppConstants.requestTimeoutSeconds,
-                ),
+    : _dio =
+          dio ??
+          Dio(
+            BaseOptions(
+              baseUrl: AppConstants.apiBaseUrl,
+              connectTimeout: const Duration(
+                seconds: AppConstants.requestTimeoutSeconds,
               ),
-            );
+              receiveTimeout: const Duration(
+                seconds: AppConstants.requestTimeoutSeconds,
+              ),
+            ),
+          );
 
   final Dio _dio;
 
   Future<List<Spot>> fetchSpots() async {
     final response = await _dio.get('/spots');
     final data = response.data as List<dynamic>;
-    return data.map((item) => Spot.fromJson(item as Map<String, dynamic>)).toList();
+    return data
+        .map((item) => Spot.fromJson(item as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/numyp/lib/services/api_client.dart
+++ b/numyp/lib/services/api_client.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+
+import '../config/constants.dart';
+import '../models/spot.dart';
+
+class ApiClient {
+  ApiClient({Dio? dio})
+      : _dio = dio ??
+            Dio(
+              BaseOptions(
+                baseUrl: AppConstants.apiBaseUrl,
+                connectTimeout: const Duration(
+                  seconds: AppConstants.requestTimeoutSeconds,
+                ),
+                receiveTimeout: const Duration(
+                  seconds: AppConstants.requestTimeoutSeconds,
+                ),
+              ),
+            );
+
+  final Dio _dio;
+
+  Future<List<Spot>> fetchSpots() async {
+    final response = await _dio.get('/spots');
+    final data = response.data as List<dynamic>;
+    return data.map((item) => Spot.fromJson(item as Map<String, dynamic>)).toList();
+  }
+}

--- a/numyp/lib/widgets/spot_detail_card.dart
+++ b/numyp/lib/widgets/spot_detail_card.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import '../config/theme.dart';
+import '../models/spot.dart';
+import 'glass_card.dart';
+
+class SpotDetailCard extends StatelessWidget {
+  const SpotDetailCard({super.key, required this.spot, this.onClose});
+
+  final Spot spot;
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: SizedBox(
+                  height: 90,
+                  width: 110,
+                  child: spot.content.imageUrl != null
+                      ? Image.network(
+                          spot.content.imageUrl!,
+                          fit: BoxFit.cover,
+                        )
+                      : Container(
+                          color: AppColors.cardSurface.withOpacity(0.5),
+                          child: const Icon(Icons.photo, color: Colors.white54),
+                        ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          child: Text(
+                            spot.content.title,
+                            style: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.textPrimary,
+                            ),
+                          ),
+                        ),
+                        if (onClose != null)
+                          IconButton(
+                            icon: const Icon(Icons.close, size: 18),
+                            color: AppColors.textSecondary,
+                            onPressed: onClose,
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        _StatusChip(label: spot.status.crowdLevel.label),
+                        const SizedBox(width: 8),
+                        _StatusChip(
+                          icon: Icons.star,
+                          label: spot.status.rating.toString(),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      spot.content.description ?? '詳細情報は後ほど公開されます。',
+                      style: const TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 13,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: [
+                        CircleAvatar(
+                          radius: 14,
+                          backgroundColor: AppColors.fantasyPurple,
+                          backgroundImage: spot.author.iconUrl != null
+                              ? NetworkImage(spot.author.iconUrl!)
+                              : null,
+                          child: spot.author.iconUrl == null
+                              ? const Icon(Icons.person, size: 16)
+                              : null,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          spot.author.username,
+                          style: const TextStyle(color: AppColors.textPrimary),
+                        ),
+                        const Spacer(),
+                        if (spot.skin.imageUrl != null)
+                          Chip(
+                            backgroundColor:
+                                AppColors.cardSurface.withOpacity(0.7),
+                            avatar: CircleAvatar(
+                              backgroundImage: NetworkImage(spot.skin.imageUrl!),
+                            ),
+                            label: Text(
+                              spot.skin.name,
+                              style: const TextStyle(color: AppColors.textPrimary),
+                            ),
+                          ),
+                      ],
+                    )
+                  ],
+                ),
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({this.icon, required this.label});
+
+  final IconData? icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppColors.cardSurface.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 16, color: AppColors.magicGold),
+            const SizedBox(width: 4),
+          ],
+          Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/numyp/lib/widgets/spot_preview_card.dart
+++ b/numyp/lib/widgets/spot_preview_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import '../config/theme.dart';
+import '../models/spot.dart';
+import 'glass_card.dart';
+
+class SpotPreviewCard extends StatelessWidget {
+  const SpotPreviewCard({super.key, required this.spot, this.onTap});
+
+  final Spot spot;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      width: 210,
+      padding: const EdgeInsets.all(12),
+      onTap: onTap,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: SizedBox.expand(
+                child: spot.content.imageUrl != null
+                    ? Image.network(spot.content.imageUrl!, fit: BoxFit.cover)
+                    : Container(
+                        color: AppColors.cardSurface.withOpacity(0.5),
+                        child: const Center(
+                          child: Icon(Icons.image_not_supported,
+                              color: Colors.white54),
+                        ),
+                      ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(
+            spot.content.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Icon(Icons.location_on, size: 16, color: AppColors.magicGold),
+              const SizedBox(width: 4),
+              Text(
+                '${spot.location.latitude.toStringAsFixed(5)}, ${spot.location.longitude.toStringAsFixed(5)}',
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 12,
+                ),
+              )
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/numyp/pubspec.yaml
+++ b/numyp/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   google_maps_flutter: ^2.14.0
   flutter_riverpod: ^2.6.1
+  dio: ^5.7.0
 
 dev_dependencies:
   flutter_test:

--- a/numyp/pubspec.yaml
+++ b/numyp/pubspec.yaml
@@ -61,7 +61,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
+  assets:
+    - env.json
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 


### PR DESCRIPTION
## Summary
- add configurable API constants and Dio client for loading spots from the backend
- model spot responses and expose them via Riverpod providers for the map
- redesign the map screen with production-ready previews and detail overlays

## Testing
- Not run (Dart SDK/Flutter not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384def375c832991f04deb914bd8cd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 環境設定ファイルの読み込みによるAPIキー／URL管理を追加
  * スポットのデータモデルおよび取得用APIクライアントを追加
  * スポット詳細カードとプレビューカードのUIコンポーネントを追加

* **改善**
  * マップ画面をリファクタリングし、マーカー表示・選択・カメラ移動・状態表示を強化
  * 起動時に環境を初期化して設定を反映するように変更

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->